### PR TITLE
visualizer: add checkbox to disable block highlighting

### DIFF
--- a/visualizer/index.html
+++ b/visualizer/index.html
@@ -231,6 +231,8 @@ MyLang {
   </div>
   <div id="options">
     <label><input type="checkbox" name="showFailures"> Show failures</label>
+    <br/>
+    <label><input type="checkbox" name="highlightBlocks" checked="true"> Highlight blocks</label>
   </div>
   <div id="measuringDiv">
     <div class="pexpr"></div>

--- a/visualizer/index.js
+++ b/visualizer/index.js
@@ -65,7 +65,7 @@ function markInterval(cm, interval, className) {
   var endPos = cm.posFromIndex(interval.endIdx);
 
   // See if the selection can be expanded to a block selection.
-  if (isBlockSelectable(cm, startPos, endPos)) {
+  if (options.highlightBlocks && isBlockSelectable(cm, startPos, endPos)) {
     return markBlock(cm, startPos.line, endPos.line, className);
   }
   cm.getWrapperElement().classList.add('highlighting');


### PR DESCRIPTION
The highlighting was a bit confusing to me when debugging my grammar.
Could we have this as an option?
