### PR TITLE
visualizer: move errors inside the code editor

### DIFF
--- a/visualizer/index.html
+++ b/visualizer/index.html
@@ -176,12 +176,9 @@
       border-right: 1px solid #ddd;
     }
 
-    .errorContainer {
-      background-color: #FCF68B;
-    }
-
     .errorItem {
       text-align: center;
+      background-color: #FCF68B;
     }
 
     .CodeMirror.highlighting {
@@ -220,7 +217,6 @@
     <div id="inputContainer">
       <h2>Test Input</h2>
       <textarea id="input">if (foobar) [x] = [3] else [x, y, z] = [foo, bar, baz]</textarea>
-      <div id="inputError" class="errorContainer"></div>
     </div><div id="grammarContainer">
       <h2>Grammar</h2>
       <textarea id="grammar">
@@ -240,7 +236,6 @@ MyLang {
          | digit
 }
 </textarea>
-      <div id="grammarError" class="errorContainer"></div>
     </div>
   </div>
   <div id="bottomSection">

--- a/visualizer/index.js
+++ b/visualizer/index.js
@@ -356,15 +356,20 @@ var errorMarks = {
 
 function hideError(category, editor) {
   if (errorMarks[category]) {
-    clearMark(editor, errorMarks[category]);
+    clearMark(editor, errorMarks[category].interval);
+    errorMarks[category].widget.clear();
+    errorMarks[category] = null;
   }
-  $('#' + category + 'Error').innerHTML = '';
 }
 
 function showError(category, editor, message, interval) {
-  var el = $('#' + category + 'Error').appendChild(createElement('.errorItem'));
+  var el = createElement('.errorItem');
   el.textContent = message;
-  errorMarks[category] = markInterval(editor, interval, 'error', false);
+  var pos = editor.posFromIndex(interval.endIdx);
+  errorMarks[category] = {
+    interval: markInterval(editor, interval, 'error', false),
+    widget: editor.addLineWidget(pos.line, el)
+  };
 }
 
 // Main


### PR DESCRIPTION
How about this? : 
![inline-errors](https://cloud.githubusercontent.com/assets/434333/8081462/eaed2c66-0f6c-11e5-893b-6bb7c77d3d65.png)
