### PR TITLE
Resolve issue #56. 

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -186,6 +186,16 @@ function missingSemanticAction(ctorName, name, type) {
   return e;
 }
 
+// --------- left-right associativity ambiguousness -----------
+
+function associativityAmbiguousness(parentName, expr) {
+  return createError(
+      'Left or Right associativity is unclear. Ensure ' + parentName +
+      ' is only on either the right or left.',
+      expr
+    );
+}
+
 // --------------------------------------------------------------------
 // Exports
 // --------------------------------------------------------------------
@@ -209,6 +219,7 @@ module.exports = {
   undeclaredRule: undeclaredRule,
   wrongNumberOfArguments: wrongNumberOfArguments,
   wrongNumberOfParameters: wrongNumberOfParameters,
+  associativityAmbiguousness: associativityAmbiguousness,
 
   throwErrors: function(errors) {
     if (errors.length === 1) {

--- a/src/pexprs-assertProperAssociativity.js
+++ b/src/pexprs-assertProperAssociativity.js
@@ -1,0 +1,60 @@
+'use strict';
+
+// --------------------------------------------------------------------
+// Imports
+// --------------------------------------------------------------------
+
+var common = require('./common');
+var errors = require('./errors');
+var pexprs = require('./pexprs');
+
+// --------------------------------------------------------------------
+// Operations
+// --------------------------------------------------------------------
+
+pexprs.PExpr.prototype.assertProperAssociativity = common.abstract(
+  'assertProperAssociativity'
+);
+
+pexprs.any.assertProperAssociativity =
+pexprs.end.assertProperAssociativity =
+pexprs.Terminal.prototype.assertProperAssociativity =
+pexprs.Range.prototype.assertProperAssociativity =
+pexprs.Param.prototype.assertProperAssociativity =
+pexprs.Lex.prototype.assertProperAssociativity =
+pexprs.UnicodeChar.prototype.assertProperAssociativity = function(ruleName) {
+  // no-op
+};
+
+pexprs.Alt.prototype.assertProperAssociativity = function(ruleName) {
+  // no-op
+};
+
+pexprs.Seq.prototype.assertProperAssociativity = function(ruleName, trueParentName, src) {
+  if (this.factors.length < 2) {
+    return;
+  }
+  if (this.factors[0] instanceof pexprs.Apply &&
+      this.factors[this.factors.length - 1] instanceof pexprs.Apply) {
+    if (this.factors[0].ruleName === this.factors[this.factors.length - 1].ruleName &&
+        this.factors[0].ruleName === trueParentName) {
+      throw errors.associativityAmbiguousness(trueParentName, src);
+    }
+  }
+};
+
+pexprs.Iter.prototype.assertProperAssociativity = function(ruleName) {
+  this.expr.assertProperAssociativity(ruleName);
+};
+
+pexprs.Not.prototype.assertProperAssociativity = function(ruleName) {
+  // no-op
+};
+
+pexprs.Lookahead.prototype.assertProperAssociativity = function(ruleName) {
+  this.expr.assertProperAssociativity(ruleName);
+};
+
+pexprs.Apply.prototype.assertProperAssociativity = function(ruleName) {
+  // no-op
+};

--- a/src/pexprs.js
+++ b/src/pexprs.js
@@ -237,3 +237,4 @@ require('./pexprs-toDisplayString');
 require('./pexprs-toArgumentNameList');
 require('./pexprs-toFailure');
 require('./pexprs-toString');
+require('./pexprs-assertProperAssociativity');

--- a/test/test-errors.js
+++ b/test/test-errors.js
@@ -251,3 +251,28 @@ test('errors for Not-of-<PExpr>', function(t) {
 
   t.end();
 });
+
+test('Error where left-right associativity is unclear', function(t) {
+  try {
+    ohm.grammar(
+      'G {\n' +
+      '  A = A "+" A -- add \n' +
+      '  | B\n' +
+      '  B = "117"\n' +
+      '}');
+    t.fail('Expected an exception to be thrown');
+  } catch (e) {
+    t.equal(e.message, 'Line 2, col 7:\n' +
+    '  1 | G {\n> 2 |   A = A "+" A -- add \n' +
+    '            ^~~~~~~\n  3 |   | B\n' +
+    'Left or Right associativity is unclear. Ensure A is only on either the right or left.');
+  }
+  ohm.grammar(
+    'G {\n' +
+    '  A = A "+" B -- add \n' +
+    '  | B\n' +
+    '  B = "117"\n' +
+    '}');
+  t.end();
+
+});


### PR DESCRIPTION
Adds new error that fires on compile of left/right associativity ambiguousness. Includes test to check change.

Solution involves finding parent for the appropriate line, passing it in and making a check that verifies the case where there is a left/right associativity issue as per the issue #56. 

I'm part of the UW group. 