### PR TITLE
fix: Incomplete variable

### DIFF
--- a/examples/markdown/markdown.mjs
+++ b/examples/markdown/markdown.mjs
@@ -72,7 +72,7 @@ function parseMarkdownContent(block) {
       return ['bold', a.children.map(c => c.content()).join('')];
     },
     italic(_1, a, _2) {
-      return ['italic', a.children.map(c => content()).join('')];
+      return ['italic', a.children.map(c => c.content()).join('')];
     },
     code: (_1, a, _2) => ['code', a.children.map(c => c.content()).join('')],
     link: (img, _1, text, _2, _3, url, _4) => [


### PR DESCRIPTION
## Problem

In `examples/markdown/markdown.mjs`, the Italic rule body doesn't work.

## Example

Adding `__Something__`, meaning italic, to the markdown in `examples/markdown/test/data/test.md` will result in the following error

```
error: Uncaught ReferenceError: content is not defined
                        return ['italic', a.children.map((c) => content()).join('')];
```
## Solution

Add `c`.