### PR TITLE
Fix package.json location (#456)

### DIFF
--- a/packages/cli/src/cli.js
+++ b/packages/cli/src/cli.js
@@ -2,8 +2,9 @@ import {Command} from 'commander';
 
 import fs from 'fs';
 import commands from './commands/index.js';
+import url from 'url';
 
-const {version} = JSON.parse(fs.readFileSync('./package.json'));
+const {version} = JSON.parse(fs.readFileSync(new url.URL('../package.json', import.meta.url)));
 
 export function ohmCli(userArgs, optsForTesting = {}) {
   const program = new Command();


### PR DESCRIPTION
From https://github.com/ohmjs/ohm/issues/456

Parse ohm's package.json file to obtain the version. cli.js was parsing the package.json in the current directory to obtain the package version.
It now parses its own package.json file, not the one from the project that is using ohm.