### PR TITLE
fix(semantics): support `asIteration()` for `_iter` nodes

### DIFF
--- a/packages/ohm-js/src/semanticsDeferredInit.js
+++ b/packages/ohm-js/src/semanticsDeferredInit.js
@@ -13,6 +13,9 @@ function initBuiltInSemantics(builtInRules) {
     nonEmpty(first, _, rest) {
       return this.iteration([first].concat(rest.children));
     },
+    self(..._children) {
+      return this;
+    },
   };
 
   Semantics.BuiltInSemantics = Semantics.createSemantics(builtInRules, null).addOperation(
@@ -22,6 +25,7 @@ function initBuiltInSemantics(builtInRules) {
         nonemptyListOf: actions.nonEmpty,
         EmptyListOf: actions.empty,
         NonemptyListOf: actions.nonEmpty,
+        _iter: actions.self,
       },
   );
 }

--- a/packages/ohm-js/test/test-semantics.js
+++ b/packages/ohm-js/test/test-semantics.js
@@ -809,6 +809,7 @@ test('asIteration', t => {
     '  Start = ListOf<letter, ","> listOf<any, ".">',
     '  anyTwo = any any',
     '  anyThree = any any any',
+    '  manyLetters = letter+',
     '}',
   ]);
   const s = g.createSemantics().addAttribute('value', {
@@ -823,10 +824,14 @@ test('asIteration', t => {
     any(_) {
       return this.sourceString;
     },
+    manyLetters(letters) {
+      return letters.asIteration().children.map(c => c.value).join('');
+    },
   });
   t.is(s(g.match('a, b, c')).value, 'abc', 'one nonempty, one empty');
   t.is(s(g.match('a, b, c 1.2.3')).value, 'abc123', 'baby you and me');
   t.is(s(g.match('')).value, '', 'both empty');
+  t.is(s(g.match('abc', 'manyLetters')).value, 'abc', 'one or more letters');
 
   // Check that we can override asIteration for ListOf, and extend it with an action
   // for a rule of our own.


### PR DESCRIPTION
# What This PR Does

Adds support for the builtin `asIteration()` semantic operation to `_iter` nodes.

Before, calling `someIterNode.asIteration()` would throw this error:
```
missingSemanticAction: Missing semantic action for '_iter' in operation 'asIteration'.
NOTE: as of Ohm v16, there is no default action for iteration nodes — see 
  https://ohmjs.org/d/dsa for details.
```

Now, `asIteration()` will just return the `_iter` node it was called on.

### Why?

I often found myself switching between `+`/`*` and `ListOf` while writing grammars. This allows semantics to continue to work as intended without changes.