### PR TITLE
Indentation fixes: dedent consumption from #465 and ignore blank lines

### DIFF
--- a/packages/ohm-js/src/findIndentation.js
+++ b/packages/ohm-js/src/findIndentation.js
@@ -19,7 +19,9 @@ export function findIndentation(input) {
 
     const indentPos = pos + indentSize;
 
-    if (indentSize > prevSize) {
+    if (!line.trim()) {
+      // Empty line, cannot be an indent or dedent.
+    } else if (indentSize > prevSize) {
       // Indent -- always only 1.
       stack.push(indentSize);
       result[indentPos] = 1;

--- a/packages/ohm-js/src/pexprs-eval.js
+++ b/packages/ohm-js/src/pexprs-eval.js
@@ -232,7 +232,7 @@ pexprs.Apply.prototype.handleCycle = function(state) {
   const memoKey = this.toMemoKey();
   let memoRec = posInfo.memo[memoKey];
 
-  if (currentLeftRecursion && currentLeftRecursion.headApplication.toMemoKey() === memoKey) {
+  if (memoRec && currentLeftRecursion && currentLeftRecursion.headApplication.toMemoKey() === memoKey) {
     // We already know about this left recursion, but it's possible there are "involved
     // applications" that we don't already know about, so...
     memoRec.updateInvolvedApplicationMemoKeys();
@@ -275,7 +275,7 @@ pexprs.Apply.prototype.reallyEval = function(state) {
   let memoRec;
 
   if (state.doNotMemoize) {
-    state.doNotMemoize = false;
+    // state.doNotMemoize = false;
   } else if (isHeadOfLeftRecursion) {
     value = this.growSeedResult(body, state, origPos, currentLR, value);
     origPosInfo.endLeftRecursion();
@@ -307,7 +307,7 @@ pexprs.Apply.prototype.reallyEval = function(state) {
 
   // Record trace information in the memo table, so that it is available if the memoized result
   // is used later.
-  if (state.isTracing() && memoRec) {
+  if (state.isTracing() && memoRec && !state.doNotMemoize) {
     const entry = state.getTraceEntry(origPos, this, succeeded, succeeded ? [value] : []);
     if (isHeadOfLeftRecursion) {
       common.assert(entry.terminatingLREntry != null || !succeeded);


### PR DESCRIPTION
The first commit (39c932d3539c8b9bac130e430c859c5e47f83ef0) in this PR applies @simonwo's patches from https://github.com/ohmjs/ohm/issues/465#issuecomment-1977985628

I suppose this is a PR for discussion, because I don't personally understand @simonwo's changes but I did find them necessary when writing a whitespace-sensitive grammar.

The second commit (454746e09fbff9b240859b462a5a2fb04ef55878) ignores blank lines when calculating indents and dedents, fixing a case like this:

```
if a:
  b

  c
```

Previously this would make a stream like `if a:\n  <indent>b\n<dedent>\n  <indent>c\n` but after it makes a stream `if a:\n  <indent>b\n\n  c\n`
