### PR TITLE
Fix some typos in documentation

### DIFF
--- a/doc/errors.md
+++ b/doc/errors.md
@@ -2,7 +2,7 @@
 
 ## Instantiating Grammars
 
-These errors can occur when [instatiating a grammar](https://github.com/cdglabs/ohm/blob/main/doc/api-reference.md#instantiating-grammars)
+These errors can occur when [instantiating a grammar](https://github.com/cdglabs/ohm/blob/main/doc/api-reference.md#instantiating-grammars)
 from a grammar definition.
 
 ### Grammar Syntax Error

--- a/doc/publishing-grammars.md
+++ b/doc/publishing-grammars.md
@@ -15,7 +15,7 @@ package supporting multiple versions of Python might be used like this:
 ```js
 const {python2} = require('./your-python-package');
 const result = python2.grammar.match('print 3');
-python2.createSemantics(result).eval();
+python2.semantics(result).eval();
 ```
 
 To package a single primary language along with other variants, you can expose


### PR DESCRIPTION
Hello,

Found two typos: one is obvious, the other one needs some attention.

Essentially the recommendation for module exports doesn't seem to match the provided example.

Cheers,